### PR TITLE
added '=' operator to the 'multi-range' filter type

### DIFF
--- a/packages/db-controller/src/filter-data/filter-data-mongo.ts
+++ b/packages/db-controller/src/filter-data/filter-data-mongo.ts
@@ -109,7 +109,12 @@ function getFilterValue(where: Where) {
       }
       break;
     case "multi-range":
-      if (operator === "!") {
+      if (operator === "=") {
+        val = {
+          min: value,
+          max: value
+        };
+      } else if (operator === "!") {
         if (typeof value === "object") {
           val = {
             $not: {


### PR DESCRIPTION
while requesting db records with filter of type multi-rang, supplying an integer value to compare to returns the whole DB.