### PR TITLE
Adding missing 'port' property to the MySQL connection object

### DIFF
--- a/packages/db-controller/src/db-connections/mysql.ts
+++ b/packages/db-controller/src/db-connections/mysql.ts
@@ -1,7 +1,7 @@
 import * as mysql from "mysql";
 import { Query } from "mysql";
 
-
+const MYSQL_DEFAULT_PORT = 3306;
 
 interface ConnectionSslDetails {
   rejectUnauthorized? : boolean
@@ -77,7 +77,7 @@ const connections: any = {};
 export function connect() {
   // before connect lets close
   close();
-  const { host, user, password, ssl } = mysqlConf;
+  const { host, port, user, password, ssl } = mysqlConf;
   for (const db of mysqlConf.dbs) {
     connections[db] = mysql.createPool({
       connectionLimit: 15,
@@ -85,7 +85,8 @@ export function connect() {
       user,
       password,
       database: db,
-      ssl:ssl
+      ssl:ssl,
+      port: port || MYSQL_DEFAULT_PORT
     });
   }
 }

--- a/packages/db-controller/src/db-connections/mysql.ts
+++ b/packages/db-controller/src/db-connections/mysql.ts
@@ -31,6 +31,7 @@ interface ConnectionDetails {
   host: string;
   dbs: string[];
   ssl?:ConnectionSslDetails;
+  port? :number
 }
 
 let mysqlConf: ConnectionDetails;


### PR DESCRIPTION
StoreX ignored the 'port' property and by this action prevented a connection to a **MySQL** instance that does not use the default port.